### PR TITLE
fix: add create permission on pods/exec to allow log rotation cronjob execution

### DIFF
--- a/charts/wazuh-operator/templates/clusterrole.yaml
+++ b/charts/wazuh-operator/templates/clusterrole.yaml
@@ -34,6 +34,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods/exec
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - events
   verbs:
   - create


### PR DESCRIPTION
fix: add create permission on pods/exec to allow log rotation cronjob execution

Solving #4 