### PR TITLE
fix: fix test-env CRD path to prevent BeforeSuite failure

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -67,7 +67,7 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "config", "crd")},
+		CRDDirectoryPaths:     []string{filepath.Join("..", "charts", "wazuh-operator", "crds")},
 		ErrorIfCRDPathMissing: true,
 	}
 


### PR DESCRIPTION
fix: fix test-env CRD path to prevent BeforeSuite failure

Solving #11 