### PR TITLE
feat: sync code formatting, add necessary kubebuilder:rbac annotations and regenerate CRDs

### DIFF
--- a/charts/wazuh-operator/crds/resources.wazuh.com_opensearchdashboards.yaml
+++ b/charts/wazuh-operator/crds/resources.wazuh.com_opensearchdashboards.yaml
@@ -2239,9 +2239,10 @@ spec:
                     operator:
                       description: |-
                         Operator represents a key's relationship to the value.
-                        Valid operators are Exists and Equal. Defaults to Equal.
+                        Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                         Exists is equivalent to wildcard for value, so that a pod can
                         tolerate all taints of a particular category.
+                        Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                       type: string
                     tolerationSeconds:
                       description: |-

--- a/charts/wazuh-operator/crds/resources.wazuh.com_opensearchindexers.yaml
+++ b/charts/wazuh-operator/crds/resources.wazuh.com_opensearchindexers.yaml
@@ -2543,7 +2543,9 @@ spec:
                           type: integer
                       type: object
                     resizePolicy:
-                      description: Resources resize policy for the container.
+                      description: |-
+                        Resources resize policy for the container.
+                        This field cannot be set on ephemeral containers.
                       items:
                         description: ContainerResizePolicy represents resource resize
                           policy for the container.
@@ -4194,9 +4196,10 @@ spec:
                     operator:
                       description: |-
                         Operator represents a key's relationship to the value.
-                        Valid operators are Exists and Equal. Defaults to Equal.
+                        Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                         Exists is equivalent to wildcard for value, so that a pod can
                         tolerate all taints of a particular category.
+                        Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                       type: string
                     tolerationSeconds:
                       description: |-

--- a/charts/wazuh-operator/crds/resources.wazuh.com_wazuhclusters.yaml
+++ b/charts/wazuh-operator/crds/resources.wazuh.com_wazuhclusters.yaml
@@ -2300,9 +2300,10 @@ spec:
                         operator:
                           description: |-
                             Operator represents a key's relationship to the value.
-                            Valid operators are Exists and Equal. Defaults to Equal.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                             Exists is equivalent to wildcard for value, so that a pod can
                             tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                           type: string
                         tolerationSeconds:
                           description: |-
@@ -5416,7 +5417,9 @@ spec:
                               type: integer
                           type: object
                         resizePolicy:
-                          description: Resources resize policy for the container.
+                          description: |-
+                            Resources resize policy for the container.
+                            This field cannot be set on ephemeral containers.
                           items:
                             description: ContainerResizePolicy represents resource
                               resize policy for the container.
@@ -7433,9 +7436,10 @@ spec:
                               operator:
                                 description: |-
                                   Operator represents a key's relationship to the value.
-                                  Valid operators are Exists and Equal. Defaults to Equal.
+                                  Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                                   Exists is equivalent to wildcard for value, so that a pod can
                                   tolerate all taints of a particular category.
+                                  Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                                 type: string
                               tolerationSeconds:
                                 description: |-
@@ -7871,9 +7875,10 @@ spec:
                         operator:
                           description: |-
                             Operator represents a key's relationship to the value.
-                            Valid operators are Exists and Equal. Defaults to Equal.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                             Exists is equivalent to wildcard for value, so that a pod can
                             tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                           type: string
                         tolerationSeconds:
                           description: |-
@@ -10349,7 +10354,7 @@ spec:
                                         resources:
                                           description: |-
                                             resources represents the minimum resources the volume should have.
-                                            If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                            Users are allowed to specify resource requirements
                                             that are lower than previous value but must still be higher than capacity recorded in the
                                             status field of the claim.
                                             More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -11235,6 +11240,24 @@ spec:
                                             description: Kubelet's generated CSRs
                                               will be addressed to this signer.
                                             type: string
+                                          userAnnotations:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              userAnnotations allow pod authors to pass additional information to
+                                              the signer implementation.  Kubernetes does not restrict or validate this
+                                              metadata in any way.
+
+                                              These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                              the PodCertificateRequest objects that Kubelet creates.
+
+                                              Entries are subject to the same validation as object metadata annotations,
+                                              with the addition that all keys must be domain-prefixed. No restrictions
+                                              are placed on values, except an overall size limitation on the entire field.
+
+                                              Signers should document the keys and values they support. Signers should
+                                              deny requests that contain keys they do not recognize.
+                                            type: object
                                         required:
                                         - keyType
                                         - signerName
@@ -12192,9 +12215,10 @@ spec:
                             operator:
                               description: |-
                                 Operator represents a key's relationship to the value.
-                                Valid operators are Exists and Equal. Defaults to Equal.
+                                Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                                 Exists is equivalent to wildcard for value, so that a pod can
                                 tolerate all taints of a particular category.
+                                Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                               type: string
                             tolerationSeconds:
                               description: |-
@@ -14224,7 +14248,7 @@ spec:
                                         resources:
                                           description: |-
                                             resources represents the minimum resources the volume should have.
-                                            If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                            Users are allowed to specify resource requirements
                                             that are lower than previous value but must still be higher than capacity recorded in the
                                             status field of the claim.
                                             More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -15110,6 +15134,24 @@ spec:
                                             description: Kubelet's generated CSRs
                                               will be addressed to this signer.
                                             type: string
+                                          userAnnotations:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              userAnnotations allow pod authors to pass additional information to
+                                              the signer implementation.  Kubernetes does not restrict or validate this
+                                              metadata in any way.
+
+                                              These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                              the PodCertificateRequest objects that Kubelet creates.
+
+                                              Entries are subject to the same validation as object metadata annotations,
+                                              with the addition that all keys must be domain-prefixed. No restrictions
+                                              are placed on values, except an overall size limitation on the entire field.
+
+                                              Signers should document the keys and values they support. Signers should
+                                              deny requests that contain keys they do not recognize.
+                                            type: object
                                         required:
                                         - keyType
                                         - signerName
@@ -16197,9 +16239,10 @@ spec:
                             operator:
                               description: |-
                                 Operator represents a key's relationship to the value.
-                                Valid operators are Exists and Equal. Defaults to Equal.
+                                Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                                 Exists is equivalent to wildcard for value, so that a pod can
                                 tolerate all taints of a particular category.
+                                Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                               type: string
                             tolerationSeconds:
                               description: |-

--- a/charts/wazuh-operator/crds/resources.wazuh.com_wazuhmanagers.yaml
+++ b/charts/wazuh-operator/crds/resources.wazuh.com_wazuhmanagers.yaml
@@ -2415,7 +2415,7 @@ spec:
                                     resources:
                                       description: |-
                                         resources represents the minimum resources the volume should have.
-                                        If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                        Users are allowed to specify resource requirements
                                         that are lower than previous value but must still be higher than capacity recorded in the
                                         status field of the claim.
                                         More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -3296,6 +3296,24 @@ spec:
                                         description: Kubelet's generated CSRs will
                                           be addressed to this signer.
                                         type: string
+                                      userAnnotations:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          userAnnotations allow pod authors to pass additional information to
+                                          the signer implementation.  Kubernetes does not restrict or validate this
+                                          metadata in any way.
+
+                                          These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                          the PodCertificateRequest objects that Kubelet creates.
+
+                                          Entries are subject to the same validation as object metadata annotations,
+                                          with the addition that all keys must be domain-prefixed. No restrictions
+                                          are placed on values, except an overall size limitation on the entire field.
+
+                                          Signers should document the keys and values they support. Signers should
+                                          deny requests that contain keys they do not recognize.
+                                        type: object
                                     required:
                                     - keyType
                                     - signerName
@@ -4250,9 +4268,10 @@ spec:
                         operator:
                           description: |-
                             Operator represents a key's relationship to the value.
-                            Valid operators are Exists and Equal. Defaults to Equal.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                             Exists is equivalent to wildcard for value, so that a pod can
                             tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                           type: string
                         tolerationSeconds:
                           description: |-
@@ -6263,7 +6282,7 @@ spec:
                                     resources:
                                       description: |-
                                         resources represents the minimum resources the volume should have.
-                                        If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                        Users are allowed to specify resource requirements
                                         that are lower than previous value but must still be higher than capacity recorded in the
                                         status field of the claim.
                                         More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -7144,6 +7163,24 @@ spec:
                                         description: Kubelet's generated CSRs will
                                           be addressed to this signer.
                                         type: string
+                                      userAnnotations:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          userAnnotations allow pod authors to pass additional information to
+                                          the signer implementation.  Kubernetes does not restrict or validate this
+                                          metadata in any way.
+
+                                          These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                          the PodCertificateRequest objects that Kubelet creates.
+
+                                          Entries are subject to the same validation as object metadata annotations,
+                                          with the addition that all keys must be domain-prefixed. No restrictions
+                                          are placed on values, except an overall size limitation on the entire field.
+
+                                          Signers should document the keys and values they support. Signers should
+                                          deny requests that contain keys they do not recognize.
+                                        type: object
                                     required:
                                     - keyType
                                     - signerName
@@ -8228,9 +8265,10 @@ spec:
                         operator:
                           description: |-
                             Operator represents a key's relationship to the value.
-                            Valid operators are Exists and Equal. Defaults to Equal.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                             Exists is equivalent to wildcard for value, so that a pod can
                             tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                           type: string
                         tolerationSeconds:
                           description: |-

--- a/charts/wazuh-operator/crds/resources.wazuh.com_wazuhworkers.yaml
+++ b/charts/wazuh-operator/crds/resources.wazuh.com_wazuhworkers.yaml
@@ -2027,7 +2027,7 @@ spec:
                                 resources:
                                   description: |-
                                     resources represents the minimum resources the volume should have.
-                                    If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                    Users are allowed to specify resource requirements
                                     that are lower than previous value but must still be higher than capacity recorded in the
                                     status field of the claim.
                                     More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
@@ -2906,6 +2906,24 @@ spec:
                                     description: Kubelet's generated CSRs will be
                                       addressed to this signer.
                                     type: string
+                                  userAnnotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      userAnnotations allow pod authors to pass additional information to
+                                      the signer implementation.  Kubernetes does not restrict or validate this
+                                      metadata in any way.
+
+                                      These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                      the PodCertificateRequest objects that Kubelet creates.
+
+                                      Entries are subject to the same validation as object metadata annotations,
+                                      with the addition that all keys must be domain-prefixed. No restrictions
+                                      are placed on values, except an overall size limitation on the entire field.
+
+                                      Signers should document the keys and values they support. Signers should
+                                      deny requests that contain keys they do not recognize.
+                                    type: object
                                 required:
                                 - keyType
                                 - signerName
@@ -3918,9 +3936,10 @@ spec:
                     operator:
                       description: |-
                         Operator represents a key's relationship to the value.
-                        Valid operators are Exists and Equal. Defaults to Equal.
+                        Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                         Exists is equivalent to wildcard for value, so that a pod can
                         tolerate all taints of a particular category.
+                        Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                       type: string
                     tolerationSeconds:
                       description: |-

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -22,21 +22,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  verbs:
-  - delete
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - pods/exec
-  verbs:
-  - create
-- apiGroups:
-  - ""
-  resources:
   - events
   verbs:
   - create
@@ -50,6 +35,21 @@ rules:
   - list
   - patch
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/exec
+  verbs:
+  - create
 - apiGroups:
   - apps
   resources:

--- a/controllers/wazuhcertificate_controller.go
+++ b/controllers/wazuhcertificate_controller.go
@@ -49,6 +49,8 @@ type WazuhCertificateReconciler struct {
 // +kubebuilder:rbac:groups=resources.wazuh.com,resources=wazuhcertificates,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=resources.wazuh.com,resources=wazuhcertificates/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=resources.wazuh.com,resources=wazuhcertificates/finalizers,verbs=update
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;delete
+// +kubebuilder:rbac:groups="",resources=pods/exec,verbs=create
 
 // Reconcile is the main reconciliation loop for WazuhCertificate
 func (r *WazuhCertificateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/controllers/wazuhcluster_controller.go
+++ b/controllers/wazuhcluster_controller.go
@@ -103,6 +103,8 @@ type WazuhClusterReconciler struct {
 // +kubebuilder:rbac:groups=resources.wazuh.com,resources=wazuhclusters,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=resources.wazuh.com,resources=wazuhclusters/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=resources.wazuh.com,resources=wazuhclusters/finalizers,verbs=update
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;delete
+// +kubebuilder:rbac:groups="",resources=pods/exec,verbs=create
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete

--- a/internal/shared/patch/hash.go
+++ b/internal/shared/patch/hash.go
@@ -67,47 +67,47 @@ type DashboardSpec struct {
 
 // ManagerMasterSpec contains fields from WazuhCluster.Spec.Manager.Master used for hash computation
 type ManagerMasterSpec struct {
-	Version           string                       `json:"version,omitempty"`
-	Resources         *corev1.ResourceRequirements `json:"resources,omitempty"`
-	StorageSize       string                       `json:"storageSize,omitempty"`
-	Image             string                       `json:"image,omitempty"`
-	NodeSelector      map[string]string            `json:"nodeSelector,omitempty"`
-	Tolerations       []corev1.Toleration          `json:"tolerations,omitempty"`
-	Affinity          *corev1.Affinity             `json:"affinity,omitempty"`
+	Version      string                       `json:"version,omitempty"`
+	Resources    *corev1.ResourceRequirements `json:"resources,omitempty"`
+	StorageSize  string                       `json:"storageSize,omitempty"`
+	Image        string                       `json:"image,omitempty"`
+	NodeSelector map[string]string            `json:"nodeSelector,omitempty"`
+	Tolerations  []corev1.Toleration          `json:"tolerations,omitempty"`
+	Affinity     *corev1.Affinity             `json:"affinity,omitempty"`
 	// Custom pod configuration
-	Env               []corev1.EnvVar        `json:"env,omitempty"`
-	EnvFrom           []corev1.EnvFromSource `json:"envFrom,omitempty"`
-	Labels            map[string]string      `json:"labels,omitempty"`
-	Annotations       map[string]string      `json:"annotations,omitempty"`
-	PodAnnotations    map[string]string      `json:"podAnnotations,omitempty"`
+	Env            []corev1.EnvVar        `json:"env,omitempty"`
+	EnvFrom        []corev1.EnvFromSource `json:"envFrom,omitempty"`
+	Labels         map[string]string      `json:"labels,omitempty"`
+	Annotations    map[string]string      `json:"annotations,omitempty"`
+	PodAnnotations map[string]string      `json:"podAnnotations,omitempty"`
 	// Extra configuration and volumes
-	ExtraConfig       string                 `json:"extraConfig,omitempty"`
-	ExtraVolumes      []corev1.Volume        `json:"extraVolumes,omitempty"`
-	ExtraVolumeMounts []corev1.VolumeMount   `json:"extraVolumeMounts,omitempty"`
+	ExtraConfig       string               `json:"extraConfig,omitempty"`
+	ExtraVolumes      []corev1.Volume      `json:"extraVolumes,omitempty"`
+	ExtraVolumeMounts []corev1.VolumeMount `json:"extraVolumeMounts,omitempty"`
 	// Monitoring configuration
 	MonitoringEnabled bool `json:"monitoringEnabled,omitempty"`
 }
 
 // ManagerWorkersSpec contains fields from WazuhCluster.Spec.Manager.Workers used for hash computation
 type ManagerWorkersSpec struct {
-	Replicas          int32                        `json:"replicas,omitempty"`
-	Version           string                       `json:"version,omitempty"`
-	Resources         *corev1.ResourceRequirements `json:"resources,omitempty"`
-	StorageSize       string                       `json:"storageSize,omitempty"`
-	Image             string                       `json:"image,omitempty"`
-	NodeSelector      map[string]string            `json:"nodeSelector,omitempty"`
-	Tolerations       []corev1.Toleration          `json:"tolerations,omitempty"`
-	Affinity          *corev1.Affinity             `json:"affinity,omitempty"`
+	Replicas     int32                        `json:"replicas,omitempty"`
+	Version      string                       `json:"version,omitempty"`
+	Resources    *corev1.ResourceRequirements `json:"resources,omitempty"`
+	StorageSize  string                       `json:"storageSize,omitempty"`
+	Image        string                       `json:"image,omitempty"`
+	NodeSelector map[string]string            `json:"nodeSelector,omitempty"`
+	Tolerations  []corev1.Toleration          `json:"tolerations,omitempty"`
+	Affinity     *corev1.Affinity             `json:"affinity,omitempty"`
 	// Custom pod configuration
-	Env               []corev1.EnvVar        `json:"env,omitempty"`
-	EnvFrom           []corev1.EnvFromSource `json:"envFrom,omitempty"`
-	Labels            map[string]string      `json:"labels,omitempty"`
-	Annotations       map[string]string      `json:"annotations,omitempty"`
-	PodAnnotations    map[string]string      `json:"podAnnotations,omitempty"`
+	Env            []corev1.EnvVar        `json:"env,omitempty"`
+	EnvFrom        []corev1.EnvFromSource `json:"envFrom,omitempty"`
+	Labels         map[string]string      `json:"labels,omitempty"`
+	Annotations    map[string]string      `json:"annotations,omitempty"`
+	PodAnnotations map[string]string      `json:"podAnnotations,omitempty"`
 	// Extra configuration and volumes
-	ExtraConfig       string                 `json:"extraConfig,omitempty"`
-	ExtraVolumes      []corev1.Volume        `json:"extraVolumes,omitempty"`
-	ExtraVolumeMounts []corev1.VolumeMount   `json:"extraVolumeMounts,omitempty"`
+	ExtraConfig       string               `json:"extraConfig,omitempty"`
+	ExtraVolumes      []corev1.Volume      `json:"extraVolumes,omitempty"`
+	ExtraVolumeMounts []corev1.VolumeMount `json:"extraVolumeMounts,omitempty"`
 }
 
 // ComputeSpecHash computes a SHA256 hash of spec fields for change detection

--- a/internal/wazuh/reconciler/cluster_reconciler.go
+++ b/internal/wazuh/reconciler/cluster_reconciler.go
@@ -316,7 +316,7 @@ func (r *ClusterReconciler) reconcileMasterNonBlocking(ctx context.Context, clus
 		extraVolumes      []corev1.Volume
 		extraVolumeMounts []corev1.VolumeMount
 		extraConfig       string
- 		annotations       map[string]string
+		annotations       map[string]string
 		podAnnotations    map[string]string
 	)
 
@@ -649,7 +649,7 @@ func (r *ClusterReconciler) reconcileWorkersNonBlocking(ctx context.Context, clu
 		extraVolumes      []corev1.Volume
 		extraVolumeMounts []corev1.VolumeMount
 		extraConfig       string
-   	annotations       map[string]string
+		annotations       map[string]string
 		podAnnotations    map[string]string
 	)
 

--- a/internal/wazuh/reconciler/manager_reconciler.go
+++ b/internal/wazuh/reconciler/manager_reconciler.go
@@ -54,7 +54,6 @@ func NewManagerReconciler(c client.Client, scheme *runtime.Scheme) *ManagerRecon
 	}
 }
 
-
 // resolveSecretKey reads a key from a secret
 func (r *ManagerReconciler) resolveSecretKey(ctx context.Context, namespace, secretName, key string) (string, error) {
 	secret := &corev1.Secret{}
@@ -67,6 +66,7 @@ func (r *ManagerReconciler) resolveSecretKey(ctx context.Context, namespace, sec
 	}
 	return string(value), nil
 }
+
 // ReconcileStandalone reconciles a standalone WazuhManager resource
 func (r *ManagerReconciler) ReconcileStandalone(ctx context.Context, manager *wazuhv1.WazuhManager) error {
 	log := logf.FromContext(ctx)

--- a/internal/wazuh/reconciler/worker_reconciler.go
+++ b/internal/wazuh/reconciler/worker_reconciler.go
@@ -62,6 +62,7 @@ func NewWorkerReconciler(c client.Client, scheme *runtime.Scheme) *WorkerReconci
 		Scheme: scheme,
 	}
 }
+
 // ReconcileStandalone reconciles a standalone WazuhWorker resource
 func (r *WorkerReconciler) ReconcileStandalone(ctx context.Context, worker *wazuhv1.WazuhWorker) error {
 	log := logf.FromContext(ctx)
@@ -240,6 +241,7 @@ func (r *WorkerReconciler) reconcileStandaloneStatefulSet(ctx context.Context, w
 
 	return nil
 }
+
 // createOrUpdate creates or updates a resource with retry on conflict
 func (r *WorkerReconciler) createOrUpdate(ctx context.Context, obj client.Object) error {
 	log := logf.FromContext(ctx)
@@ -636,4 +638,3 @@ func (r *WorkerReconciler) EvaluateDrainFeasibility(ctx context.Context, cluster
 	drainer := drain.NewManagerDrainer(r.wazuhClient, logf.FromContext(ctx), drainConfig)
 	return drainer.EvaluateFeasibility(ctx, nodeName)
 }
-


### PR DESCRIPTION
feat: sync code formatting, add necessary kubebuilder:rbac annotations and regenerate CRDs

- gofmt updated files that were not properly formatted.
- Add missing +kubebuilder:rbac annotations so make manifests keeps required pods and pods/exec permissions.
- Regenerate CRDs to match the current codebase.

Solving #15 