### PR TITLE
fix: re-include directories in .dockerignore to avoid build failure

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@
 **
 
 # Re-include Go source files (but not *_test.go)
+!**/
 !**/*.go
 **/*_test.go
 


### PR DESCRIPTION
fix: re-include directories in .dockerignore to avoid build failure

Solving #19 