### PR TITLE
fix: add necessary kubebuilder network policy rbac annotation

### DIFF
--- a/internal/networking/reconciler/networkpolicy_reconciler.go
+++ b/internal/networking/reconciler/networkpolicy_reconciler.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package reconciler
 
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete
+
 import (
 	"context"
 	"fmt"


### PR DESCRIPTION
fix: add necessary kubebuilder network policy rbac annotation

Solving #33 