### PR TITLE
fix: run init container fot set vm.max_map_count as privileged root

### DIFF
--- a/internal/opensearch/builder/deployments/indexer.go
+++ b/internal/opensearch/builder/deployments/indexer.go
@@ -689,11 +689,13 @@ if [ "$DESIRED" -gt "$CURRENT" ]; then
 fi`, config.VMMaxMapCount()),
 			},
 			SecurityContext: &corev1.SecurityContext{
-				Privileged: boolPtr(true),
-				// Override pod-level seccomp profile to allow sysctl syscall
-				SeccompProfile: &corev1.SeccompProfile{
-					Type: corev1.SeccompProfileTypeUnconfined,
+				Capabilities: &corev1.Capabilities{
+					Add: []corev1.Capability{
+						"SYS_ADMIN",
+					},
 				},
+				Privileged: boolPtr(true),
+				RunAsUser:  int64Ptr(0),
 			},
 		},
 	}

--- a/internal/opensearch/builder/deployments/indexer_nodepool.go
+++ b/internal/opensearch/builder/deployments/indexer_nodepool.go
@@ -666,7 +666,13 @@ ls -la /tmp/config/
 				"sysctl -w vm.max_map_count=262144 || echo 'sysctl failed - vm.max_map_count might need to be set on the host node'",
 			},
 			SecurityContext: &corev1.SecurityContext{
+				Capabilities: &corev1.Capabilities{
+					Add: []corev1.Capability{
+						"SYS_ADMIN",
+					},
+				},
 				Privileged: boolPtr(true),
+				RunAsUser:  int64Ptr(0),
 			},
 		},
 	}


### PR DESCRIPTION
After testing on GKE Standard:

- I removed `seccompProfile: Unconfined` because it did not affect the capabilities required by this initContainer.
- We must explicitly run this initContainer with `runAsUser: 0` to avoid permission errors (`sysctl: error setting key 'vm.max_map_count': Permission denied`).
- We also must explicitly run this initContainer with `privileged: true` to avoid the read‑only filesystem error (`sysctl: error setting key 'vm.max_map_count': Read-only file system`).

Using `SYS_ADMIN` alone was not sufficient in this environment.

Solving #3 