### PR TITLE
chore: fix GCS backups by enabling rclone ADC/Workload Identity (env_auth=true) to avoid interactive OAuth

### DIFF
--- a/internal/wazuh/builder/jobs/backup_job.go
+++ b/internal/wazuh/builder/jobs/backup_job.go
@@ -146,8 +146,8 @@ func (b *BackupJobBuilder) buildRcloneConfig() string {
 		if storage.CredentialsSecret != nil {
 			return fmt.Sprintf(`rclone config create remote gcs %sservice_account_file=/mnt/credentials/credentials-file`, project)
 		}
-		// Workload Identity: no explicit credentials
-		return fmt.Sprintf(`rclone config create remote gcs %s`, project)
+		// Workload Identity / ADC: use env_auth to avoid OAuth prompt
+		return fmt.Sprintf(`rclone config create remote gcs %senv_auth=true`, project)
 
 	case constants.RepositoryTypeAzure:
 		account := ""


### PR DESCRIPTION
chore: fix GCS backups by enabling rclone ADC/Workload Identity (env_auth=true) to avoid interactive OAuth

Related #38 