### PR TITLE
chore: fix(backup): use GCS env_auth in restore_job and add bucket_policy_only in rclone.

### DIFF
--- a/internal/wazuh/builder/jobs/backup_job.go
+++ b/internal/wazuh/builder/jobs/backup_job.go
@@ -159,10 +159,10 @@ func (b *BackupJobBuilder) buildRcloneConfig() string {
 			project = fmt.Sprintf("project_number=%s ", storage.GCS.Project)
 		}
 		if storage.CredentialsSecret != nil {
-			return fmt.Sprintf(`rclone config create remote gcs %sservice_account_file=/mnt/credentials/credentials-file`, project)
+			return fmt.Sprintf(`rclone config create remote gcs %sservice_account_file=/mnt/credentials/credentials-file bucket_policy_only=true`, project)
 		}
 		// Workload Identity / ADC: use env_auth to avoid OAuth prompt
-		return fmt.Sprintf(`rclone config create remote gcs %senv_auth=true`, project)
+		return fmt.Sprintf(`rclone config create remote gcs %senv_auth=true bucket_policy_only=true`, project)
 
 	case constants.RepositoryTypeAzure:
 		account := ""

--- a/internal/wazuh/builder/jobs/restore_job.go
+++ b/internal/wazuh/builder/jobs/restore_job.go
@@ -177,9 +177,10 @@ func (b *RestoreJobBuilder) buildRcloneConfig() string {
 			project = fmt.Sprintf("project_number=%s ", gcs.Project)
 		}
 		if gcs.CredentialsSecret != nil {
-			return fmt.Sprintf(`rclone config create remote gcs %sservice_account_file=/mnt/credentials/credentials-file`, project)
+			return fmt.Sprintf(`rclone config create remote gcs %sservice_account_file=/mnt/credentials/credentials-file bucket_policy_only=true`, project)
 		}
-		return fmt.Sprintf(`rclone config create remote gcs %s`, project)
+		// Workload Identity / ADC: use env_auth to avoid OAuth prompt
+		return fmt.Sprintf(`rclone config create remote gcs %senv_auth=true bucket_policy_only=true`, project)
 	}
 
 	if source.Azure != nil {


### PR DESCRIPTION
chore: fix(backup): use GCS env_auth in restore_job and add bucket_policy_only in rclone.

Related: #38